### PR TITLE
Updates posts page, flickr api request

### DIFF
--- a/entree_project/entree/templates/entree/posts.html
+++ b/entree_project/entree/templates/entree/posts.html
@@ -14,7 +14,7 @@
     <div class="row">
 
         <div class="col-lg-12">
-            <h1 class="page-header">Instagram Posts</h1>
+            <h1 class="page-header">Flickr Posts</h1>
         </div>
 
         <div class="col-lg-12">

--- a/entree_project/entree/views.py
+++ b/entree_project/entree/views.py
@@ -105,6 +105,7 @@ def posts(request):
         uri += '&privacy_filter=1'
         uri += '&format=json'
         uri += '&has_geo=1'
+        uri += '&per_page=25'
 
         text = requests.get(uri).text
         # For some reason Flickr returns invalid JSON, wrapped with this bs:


### PR DESCRIPTION
The posts page now says “Flickr Posts” instead of “Instagram Posts”.
The API now returns only the first 25 photos, instead of 100 (this
caused the page to load slowly).
